### PR TITLE
Include use strict in logstash.js

### DIFF
--- a/lib/logstash.js
+++ b/lib/logstash.js
@@ -1,3 +1,5 @@
+'use scrict';
+
 const net = require('net');
 const util = require('util');
 const events = require('events');


### PR DESCRIPTION
If I run this using node `v4.4.7` I get the following error. If I make the change in this PR, the issue is resolved and the code works as expected.

```
C:\project\node_modules\good-logstash-tcp\lib\logstash.js:12
class Logstash {
^^^^^

SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode
    at exports.runInThisContext (vm.js:53:16)
    at Module._compile (module.js:373:25)
    at Object.Module._extensions..js (module.js:416:10)
    at Module.load (module.js:343:32)
    at Function.Module._load (module.js:300:12)
    at Module.require (module.js:353:17)
    at require (internal/module.js:12:17)
    at Object.<anonymous> (C:\project\node_modules\good-logstash-tcp\lib\index.js:5:18)
    at Module._compile (module.js:409:26)
    at Object.Module._extensions..js (module.js:416:10)
```
